### PR TITLE
Restore missing preview images in DecapCMS

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,7 +10,7 @@ import icon from "astro-icon";
 
 import sitemap from "@astrojs/sitemap";
 
-import removeOriginalImages from "./src/lib/integration";
+// import removeOriginalImages from "./src/lib/integration";
 
 import image from "@jcayzac/astro-image-service-ng";
 
@@ -33,7 +33,7 @@ export default defineConfig({
     image({
       defaultFormat: "webp",
     }),
-    removeOriginalImages(),
+    // removeOriginalImages(),
     webmanifest({
       /**
        * required


### PR DESCRIPTION
Comment out the import and usage of removeOriginalImages script in AstroConfig

It's only needed when you have a VERY large site with thousands of original images and Netlify refuses to deploy